### PR TITLE
Fix set_coordinate_transform and transform_raw_state methods

### DIFF
--- a/robel/components/tracking/utils/coordinate_system.py
+++ b/robel/components/tracking/utils/coordinate_system.py
@@ -48,6 +48,8 @@ class CoordinateSystem:
         if transform.shape != (3, 3):
             raise ValueError('')
 
+        self._coordinate_transform = transform
+
     def set_global_transform(self, translation: np.ndarray,
                              rotation: np.ndarray):
         """Sets the global transform."""
@@ -95,12 +97,11 @@ class CoordinateSystem:
         rot = state.rot
         vel = state.vel
         angular_vel = state.angular_vel
-        if self._coordinate_transform:
+        if self._coordinate_transform is not None:
             if pos is not None:
                 pos = np.matmul(self._coordinate_transform, pos)
             if rot is not None:
-                rot = np.matmul(self._coordinate_transform, rot)
-                rot = np.matmul(rot, np.transpose(self._coordinate_transform))
+                rot = np.matmul(np.transpose(self._coordinate_transform), rot)
             if vel is not None:
                 vel = np.matmul(self._coordinate_transform, vel)
             if angular_vel is not None:

--- a/robel/components/tracking/vr_tracker.py
+++ b/robel/components/tracking/vr_tracker.py
@@ -32,6 +32,7 @@ class VrTrackerComponent(HardwareTrackerComponent):
     _VR_CLIENT = None
 
     # Transform from OpenVR space (y upwards) to simulation space (z upwards).
+    # Rotate coordinate system along x axis on pi/2 clockwise
     GLOBAL_TRANSFORM = np.array([[1, 0, 0], [0, 0, -1], [0, 1, 0]],
                                 dtype=np.float32)
 


### PR DESCRIPTION
There was no set action in set_coordinate_transform method



Coordinate transformation was incorrect in transform_raw_state method. There was redundant matrix multiplication.  